### PR TITLE
vorbis-tools: rebase patches, getopt patch was failing to merge

### DIFF
--- a/vorbis-tools/0001-utf8-add-empty-convert_free_charset-for-Windows.patch
+++ b/vorbis-tools/0001-utf8-add-empty-convert_free_charset-for-Windows.patch
@@ -1,4 +1,4 @@
-From 3c5c895df8918a1ee9bcd3c7149208c6df494bad Mon Sep 17 00:00:00 2001
+From 682775828a6d4ba4092b4226ddb83ed3ce62374e Mon Sep 17 00:00:00 2001
 From: Christopher Degawa <ccom@randomderp.com>
 Date: Mon, 21 Apr 2025 09:58:28 -0500
 Subject: [PATCH 1/2] utf8: add empty convert_free_charset for Windows
@@ -24,5 +24,5 @@ index e1199bc..f032339 100644
  	 * code.
  	 */
 -- 
-2.49.0
+2.49.0.windows.1
 

--- a/vorbis-tools/0002-getopt-just-remove-it.patch
+++ b/vorbis-tools/0002-getopt-just-remove-it.patch
@@ -1,4 +1,4 @@
-From 9447b763432b709967ad6173adea811034d16856 Mon Sep 17 00:00:00 2001
+From 6abe7c42cf380a59dfdd02de816b9e7c75066a8a Mon Sep 17 00:00:00 2001
 From: Christopher Degawa <ccom@randomderp.com>
 Date: Thu, 8 May 2025 11:09:04 -0500
 Subject: [PATCH 2/2] getopt: just remove it
@@ -21,7 +21,7 @@ Signed-off-by: Christopher Degawa <ccom@randomderp.com>
  delete mode 100644 share/getopt1.c
 
 diff --git a/configure.ac b/configure.ac
-index 6751ec8..c7f4672 100644
+index 8cd0305..c4fae97 100644
 --- a/configure.ac
 +++ b/configure.ac
 @@ -193,7 +193,7 @@ fi
@@ -34,14 +34,14 @@ index 6751ec8..c7f4672 100644
  
  I18N_CFLAGS='-I$(top_srcdir)/intl'
 diff --git a/include/Makefile.am b/include/Makefile.am
-index ad90d8a..d4d249a 100644
+index bea9c4f..142cadb 100644
 --- a/include/Makefile.am
 +++ b/include/Makefile.am
 @@ -1,3 +1,3 @@
  ## Process this file with automake to produce Makefile.in
  
--EXTRA_DIST = utf8.h getopt.h i18n.h base64.h picture.h
-+EXTRA_DIST = utf8.h i18n.h base64.h picture.h
+-EXTRA_DIST = utf8.h getopt.h gettext.h i18n.h base64.h picture.h
++EXTRA_DIST = utf8.h gettext.h i18n.h base64.h picture.h
 diff --git a/include/getopt.h b/include/getopt.h
 deleted file mode 100644
 index cfcc92c..0000000
@@ -1509,5 +1509,5 @@ index 2f1e17a..58015ab 100644
  #include "i18n.h"
  
 -- 
-2.49.0
+2.49.0.windows.1
 


### PR DESCRIPTION
This PR fixes the getopt patch applying with vorbis-tools commit e07cf6e4b966c15a33adbc3b90909e89f8642ceb.

include/Makefile.am had been modified since to add more .h files to EXTRA_DIST. To fix the resulting conflict, I just used the line from upstream except I removed getopt.h. Everything else rebased cleanly.